### PR TITLE
add more sophisticated sudo rule handling

### DIFF
--- a/TODO.markdown
+++ b/TODO.markdown
@@ -1,0 +1,4 @@
+- The README is out of date in relation to
+* RightLink10 support
+* the manage_rightlink_sudo parameter to class 'rightscale'.
+

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,16 +13,22 @@
 # [*rest_client*]
 #   Supporting rest_client Gem Version to Install
 #
+# [*manage_rightlink_sudo*]
+#   Drop a sudoers file for necessary RightLink perms.
+#   If set to Boolean false sudoers rules will be left as
+#   populated by RightLink installer.
+#
 # === Authors
 #
 # Matt Wise <matt@nextdoor.com>
 #
 class rightscale (
-  $right_api_client = $rightscale::params::right_api_client,
-  $right_aws        = $rightscale::params::right_aws,
-  $rest_client      = $rightscale::params::rest_client,
-  $rest_package     = $rightscale::params::rest_package,
-  $rest_provider    = $rightscale::params::rest_provider,
+  $right_api_client       = $rightscale::params::right_api_client,
+  $right_aws              = $rightscale::params::right_aws,
+  $rest_client            = $rightscale::params::rest_client,
+  $rest_package           = $rightscale::params::rest_package,
+  $rest_provider          = $rightscale::params::rest_provider,
+  $manage_rightlink_sudo  = true
   ) inherits ::rightscale::params {
 
   # pretty sure our version of stdlib does not include validate_integer
@@ -31,11 +37,40 @@ class rightscale (
   unless is_integer($::rightlink_maj_version) {
     fail("\$::rightlink_maj_version is \'${::rightlink_maj_version}\' but must be Integer!")
   }
-  
+
+  validate_bool($manage_rightlink_sudo)
+
+  if $manage_rightlink_sudo { include ::sudo }
+
   case $::rightlink_maj_version {
-    10: { include ::sudo }
-    
+    10: {
+      if $manage_rightlink_sudo {
+        sudo::conf { 'rightlink10_sudoers':
+          content => template(
+            "${module_name}/header.erb",
+            "${module_name}/rightlink10_sudo.erb"
+          )
+        }
+      }
+    }
+
     6: {
+      if $manage_rightlink_sudo {
+        sudo::conf { 'rightscale_users':
+          content => template(
+            "${module_name}/header.erb",
+            "${module_name}/rightscale_users_sudo.erb"
+          )
+        }
+
+        sudo::conf { 'rightscale':
+          content => template(
+            "${module_name}/header.erb",
+            "${module_name}/rightscale_sudo.erb"
+            )
+        }
+      }
+
       # Install the required gems in order. These gems support the custom
       # Hiera backend as well as the puppet rs-facts plugin that gathers
       # common RightScale facts.
@@ -44,12 +79,12 @@ class rightscale (
         $rest_package:
           ensure   => $rest_client,
           provider => $rest_provider;
-        
+
         'right_aws':
           ensure   => $right_aws,
           provider => 'gem',
           require  => Package[$rest_package];
-        
+
         'right_api_client':
           ensure          => $right_api_client,
           provider        => 'gem',
@@ -57,7 +92,7 @@ class rightscale (
           require         => Package[$rest_package];
       }
     }
-    
+
     default: {
       fail("RightLink ${::rightlink_maj_version} is not supported by this module!")
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,12 +23,12 @@ class rightscale::params {
     'Ubuntu': {
       $rest_provider = 'apt'
       $rest_package  = 'ruby-rest-client'
-      $rest_client   = 'installed'
+      $rest_client   = '1.6.7-1'
     }
     default: {
       $rest_provider = 'gem'
       $rest_package  = 'rest-client'
-      $rest_client   = '1.6.7'
+      $rest_client   = '1.6.7-1'
     }
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "rightscale",
-    "version": "0.1.1",
+    "version": "1.0.0",
     "source": "https://github.com/Nextdoor/puppet_rightscale",
     "author": "Nextdoor",
     "license": "Apache-2.0",

--- a/spec/classes/rightscale_spec.rb
+++ b/spec/classes/rightscale_spec.rb
@@ -12,33 +12,82 @@ describe '::rightscale', :type => 'class' do
       :lsbdistrelease         => '12.04',
       :lsbmajdistrelease      => '12',
       :kernel                 => 'linux',
+      :is_rightscale          => true,
     }
   end
-  
-  context 'default params and RightLink6' do
 
+  context 'default params and RightLink6' do
     it do
       facts.merge!(
         {
-          :is_rightscale         => true,
           :rightlink_version     => '6.0.0',
           :rightlink_maj_version => 6
         }
       )
-      
+
       should compile.with_all_deps
-      should contain_package('ruby-rest-client').with(
-        'ensure'   => 'installed',
-        'provider' => 'apt')
+
       should contain_package('right_aws').with(
-        'ensure' => '3.1.0')
+               'ensure' => '3.1.0')
       should contain_package('right_api_client').with(
-        'ensure' => '1.5.19')
+               'ensure' => '1.5.19')
+
+      should contain_class('sudo')
+      should contain_sudo__conf('rightscale_users').with(
+               'content' => /%rightscale_sudo\s+ALL=NOPASSWD\:\s+ALL/)
+      should contain_sudo__conf('rightscale').with(
+               'content' => /rightscale\s+ALL=\(ALL\)NOPASSWD/)
+    end
+  end
+
+  context 'default params and RightLink10' do
+    it do
+      facts.merge!(
+        {
+          :rightlink_version     => '10.0.0',
+          :rightlink_maj_version => 10
+        }
+      )
+
+      should compile.with_all_deps
+      should contain_class('sudo')
+      should contain_sudo__conf('rightlink10_sudoers').with(
+               'content' => /rightlink\s+ALL=\(ALL\)\s+SETENV:NOPASSWD\:ALL/)
+    end
+  end
+
+  context 'RightLink6 manage_rightlink_sudo == false' do
+    let(:params) { { :manage_rightlink_sudo => false } }
+    it do
+      facts.merge!(
+        {
+          :rightlink_version => '6.0.0',
+          :rightlink_maj_version => 6
+        }
+      )
+
+      should_not contain_class('sudo')
+      should_not contain_sudo__conf('rightlink10_sudoers')
+    end
+  end
+
+  context 'RightLink10 manage_rightlink_sudo == false' do
+    let(:params) { { :manage_rightlink_sudo => false } }
+    it do
+      facts.merge!(
+        {
+          :rightlink_version => '10.0.0',
+          :rightlink_maj_version => 10
+        }
+      )
+
+      should_not contain_class('sudo')
+      should_not contain_sudo__conf('rightscale_users')
+      should_not contain_sudo__conf('rightscale')
     end
   end
 
   context 'CentOS and RightLink' do
-
     it do
       facts.merge!(
         {
@@ -48,29 +97,12 @@ describe '::rightscale', :type => 'class' do
           :rightlink_maj_version => 6
         }
       )
-      
+
       should compile.with_all_deps
-      should contain_package('rest-client').with(
-        'ensure'   => '1.6.7',
-        'provider' => 'gem')
       should contain_package('right_aws').with(
         'ensure' => '3.1.0')
       should contain_package('right_api_client').with(
         'ensure' => '1.5.19')
-    end
-  end
-  context 'default params and RightLink10' do
-    it do
-      facts.merge!(
-        {
-          :is_rightscale         => true,
-          :rightlink_version     => '10.0.0',
-          :rightlink_maj_version => 10
-        }
-      )
-      
-      should compile.with_all_deps
-      should contain_class('sudo')
     end
   end
 

--- a/templates/header.erb
+++ b/templates/header.erb
@@ -1,0 +1,5 @@
+##
+## This file is managed by Puppet via nextdoor/rightscale.
+## Manual changes will be over-written by Puppet!
+##
+

--- a/templates/rightlink10_sudo.erb
+++ b/templates/rightlink10_sudo.erb
@@ -1,0 +1,17 @@
+# Rightlink service startup requires these directives:
+Defaults:root !requiretty
+Defaults:rightlink !requiretty
+Defaults:rightlink !env_reset
+root ALL=(ALL) SETENV:ALL
+
+# Blanket permissions. If you wish to remove the NOPASSWD:ALL line and tighten
+# permissions, you must add in permissions for (1) lifecycle management (reboot/terminate)
+# via /sbin/init and (2) managed login. The minimal set of permissions to do this
+# are given below. The first line below would allow (1) and second would allow (2)
+# rightlink ALL=(root) NOPASSWD:/sbin/init
+# rightlink ALL=(rightscale) NOPASSWD:/usr/bin/tee /home/rightscale/.ssh/authorized_keys
+rightlink ALL=(ALL) SETENV:NOPASSWD:ALL
+
+# Created by RightScale to support RightScale managed login
+rightscale ALL=(ALL) NOPASSWD:ALL
+

--- a/templates/rightscale_sudo.erb
+++ b/templates/rightscale_sudo.erb
@@ -1,0 +1,4 @@
+# RightScale: please leave these rules in place, else RightLink may not function
+
+rightscale ALL=(ALL)NOPASSWD: /usr/bin/useradd,/usr/sbin/useradd,/bin/useradd,/sbin/useradd,/usr/bin/usermod,/usr/sbin/usermod,/bin/usermod,/sbin/usermod,/bin/chmod,/bin/tar,/usr/bin/unzip,/bin/mv,/bin/chown,/bin/sh,/bin/bash
+Defaults:rightscale !requiretty

--- a/templates/rightscale_users_sudo.erb
+++ b/templates/rightscale_users_sudo.erb
@@ -1,0 +1,11 @@
+# The rightscale_sudo group contains every user who has superuser privileges
+# as determined by their RightScale account permissions. RightLink updates
+# this group in near-realtime as users' roles evolve over time.
+#
+# By default, anyone in this group can sudo any command and TTY is not required
+# (to support ssh -c).
+#
+# Feel free to customize these rules as you see fit.
+
+%rightscale_sudo ALL=NOPASSWD: ALL
+Defaults:%rightscale_sudo !requiretty


### PR DESCRIPTION
@diranged @siminm 

1. Class rightscale now provides a class parameter to turn off any manipulation of sudoers at all. This is done to make it easier to wrap the class in a profile where the team would prefer that the profile handle all of the sudoers config including classication of class 'sudo'. Default is to allow the class to manipulate sudoers config directly. 

2. Better (more thorough -- via templating ) handling of the sudoers configs for RightLink6 and RightLink10. These configs do *not* currently require templating (no ERB subst) but I chose template() as opposed to a File resources for future expansion and to make sure that the configs are included in the node's catalog.

3. Better tests given the new sudoers functionality.

4. Addition of a TODO.markdown to, among other things, call out that the README.md needs to be updated. A quick pass thru it turned up incomplete information as to the current behavior and sometimes incorrect info. 