### PR TITLE
Rl10 rsc tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ spec/fixtures/modules
 *.swp
 .rsync-filter
 spec/fixtures/manifests
+\#*

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: ruby
 matrix:
   fast_finish: true
   include:
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION=3.7.0
     - rvm: 1.9.3
       env: PUPPET_GEM_VERSION=3.7.0
     - rvm: 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ language: ruby
 matrix:
   fast_finish: true
   include:
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION=3.6.0
-    - rvm: 1.8.7
-      env: PUPPET_GEM_VERSION=3.7.0
     - rvm: 1.9.3
       env: PUPPET_GEM_VERSION=3.7.0
     - rvm: 1.9.3

--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,13 @@ if '1.8.7' == RUBY_VERSION or '1.9.3' == RUBY_VERSION or '2.0.0' == RUBY_VERSION
   listen_version = '1.3.1'
   rest_client_version = '1.6.8'
   logging_version = '1.8.2'
+  rake_version = '10.5.0'
 else
   rspec_core_version = '>= 3.4.1'
   listen_version = '>= 3.0.5'
   rest_client_version = '>= 1.8.0'
   logging_version = '>= 2.0.0'
+  rake_version = '>= 11.1.2'
 end
 
 # Required for unit testing
@@ -17,7 +19,7 @@ gem 'facter', :require => false, :group => :test
 gem 'puppet', '3.7.4', :require => false, :group => :test
 gem 'puppet-lint', :require => false, :group => :test
 gem 'puppetlabs_spec_helper', :require => false, :group => :test
-gem 'rake', :require => false, :group => :test
+gem 'rake', rake_version, :require => false, :group => :test
 gem 'rest-client', rest_client_version, :require => false, :group => :test
 gem 'listen', listen_version, :require => false, :group => :test
 gem 'rspec-core', rspec_core_version, :require => false, :group => :test

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-if '1.8.7' == RUBY_VERSION
+if '1.8.7' == RUBY_VERSION or '1.9.3' == RUBY_VERSION or '2.0.0' == RUBY_VERSION
   rspec_core_version = '3.1.7'
   listen_version = '1.3.1'
   rest_client_version = '1.6.8'

--- a/Guardfile
+++ b/Guardfile
@@ -1,8 +1,9 @@
 guard 'remote-sync',
       :ssh => true,
-      :source => 'lib/facter',
-      :destination => "/tmp",
+      :source => 'lib/',
+      :destination => '/var/lib/puppet/lib',
       :user => 'root',
+      :delete => false,
       :recursive => true,
       :verbose => true,
       :progress => true,
@@ -11,6 +12,6 @@ guard 'remote-sync',
       :timeout => 10,
       :remote_address => ENV['RIGHTSCALE_NODE'] do
 
-  watch(%r{^.+\.(pp|rb)$})
+  watch(%r{^.+$})
   
 end

--- a/lib/facter/rightlink_maj_version.rb
+++ b/lib/facter/rightlink_maj_version.rb
@@ -10,6 +10,8 @@
 #
 Facter.add(:rightlink_maj_version) do
   confine :kernel => %w{Linux Windows}
+  confine :rightlink_version
+
   setcode do
 
     rightlink_version = Facter.value(:rightlink_version)

--- a/lib/facter/rightlink_self_href.rb
+++ b/lib/facter/rightlink_self_href.rb
@@ -1,0 +1,36 @@
+# Fact: rightlink_self_href
+#
+# Offer value which would reside in RS_SELF_HREF during a RightScript run
+# as a Facter fact.
+#
+# Values: nil or the self href
+#
+# Notes:
+#
+# Author: Nathan Valentine - <nrvale0@gmail.com|nathan@nextdoor.com>
+#
+Facter.add(:rightlink_self_href) do
+  confine :kernel => %w{Linux Windows}
+  confine :is_rightscale => [true, 'true']
+  confine :rightlink_maj_version => 10
+
+  setcode do
+    rightlink_self_href = nil
+
+    rightlink_maj_version = Facter.value(:rightlink_maj_version)
+    Facter.debug("rightlink_self_href:: detected RightLink version #{rightlink_maj_version}...")
+
+    case rightlink_maj_version
+    when 10, '10'
+      rightlink_self_href = Facter::Util::Resolution.exec("rsc --rl10 cm15 --x1 ':has(.rel:val(\"self\")).href'"\
+                                                          " index_instance_session /api/sessions/instance")
+      Facter.debug("rightlink_self_href:: captured value from rsc: #{rightlink_self_href}")
+    when 6, '6'
+      Facter.debug("rightlink_self_href:: Detected RightLink 6; doing nothing.")
+    else
+      Facter.debug("rightlink_self_href:: Detected unsupported rightlink_maj_version: #{rightlink_maj_version}.")
+    end
+
+    rightlink_self_href
+  end
+end

--- a/lib/puppet/provider/rs_tag/rs_tag.rb
+++ b/lib/puppet/provider/rs_tag/rs_tag.rb
@@ -35,8 +35,12 @@
 require 'rubygems'
 require 'json'
 
-Puppet::Type.type(:rs_tag).provide(:ruby) do
+Puppet::Type.type(:rs_tag).provide(:rs_tag) do
   desc "Manage RightScale tags for a server"
+
+  confine :is_rightscale => true, :rightlink_maj_version => 6
+  defaultfor :rightlink_maj_version => 6
+  
   commands :rs_tag => 'rs_tag'
 
   mk_resource_methods
@@ -79,7 +83,7 @@ Puppet::Type.type(:rs_tag).provide(:ruby) do
       # Now populate some instance properties about the state of this tag
       properties[:ensure]   = :present
       properties[:value]    = v.join('=')
-      properties[:provider] = :ruby
+      properties[:provider] = :rs_tag
       properties[:name]     = n
 
       # Log out out and then generate a new instance with the properties

--- a/lib/puppet/provider/rs_tag/rsc.rb
+++ b/lib/puppet/provider/rs_tag/rsc.rb
@@ -1,0 +1,137 @@
+# License
+#
+# Copyright 2014 Nextdoor.com, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# Author: Nathan Valentine <nathan@nextdoor.com|nrvale0@gmail.com>
+# - Some code is lifted from rs_tag.rb.
+#
+
+require 'rubygems'
+require 'json'
+
+require_relative '../../../puppet_x/rightscale/utils.rb'
+
+Puppet::Type.type(:rs_tag).provide(:rsc) do
+  desc "Manage RightScale tags for a server"
+
+  confine :is_rightscale => true, :rightlink_maj_version => 10
+  defaultfor :rightlink_maj_version => 10
+
+  commands :rsc => 'rsc'
+
+  mk_resource_methods
+
+  # Fetch all of our tags and pre-populate resource objects for each one
+  # so that puppet knows which tags are already set.
+  def self.get_tags()
+    tag_properties = {}
+
+    #    rightlink_self_href = Facter.value(:rightlink_self_href)
+    rightlink_self_href = Facter.value(:rightlink_self_href)
+    query_cmd = %W(--rl10 cm15 by_resource /api/tags/by_resource
+                   resource_hrefs[]=#{rightlink_self_href})
+
+    begin
+      Puppet.debug("rs_tag:: command: rsc %s" % query_cmd)
+      output = rsc(query_cmd)
+#      puts "\nrsc output: #{output}"
+      json_output = JSON.parse(output)
+#      puts "\njson_output: #{json_output}"
+      tags = json_output[0]['tags']
+#      puts "\ntags: #{tags}"
+#      tags = JSON.parse(rsc(query_cmd))[0]['tags']
+    rescue Puppet::ExecutionFailure, JSON::ParserError => e
+      Puppet.debug("Rs_tag execution had an error -> #{e.inspect}")
+      return nil
+    end
+    
+    Puppet.debug("rs_tag::rsc :: tags: #{tags}")
+    
+    # Dump all the tags into a hash
+    providers = []
+    tags.each do |tag|
+      # Create a new fresh properties hash
+      properties = {}
+
+      # Split our tag into a name/value
+      k, v = tag['name'].split('=', 2)
+      Puppet::debug("Rs_tag::rsc::get_tags: k: #{k}, v: #{v}")
+
+      # Now populate some instance properties about the state of this tag
+      properties[:ensure]   = :present
+      properties[:value]    = v
+      properties[:provider] = :rsc
+      properties[:name]     = k
+
+      Puppet.debug("Tag properties: #{properties.inspect}")
+      providers << new(properties)
+    end
+    providers
+  end
+
+  
+  def self.instances
+    self.get_tags()
+  end
+
+  
+  def self.prefetch(resources)
+    i = instances
+    return nil if not i
+
+    i.each do |prov|
+      if resource = resources[prov.name]
+        resource.provider = prov
+      end
+    end
+  end
+
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  
+  def create
+    rightlink_self_href = Facter.value(:rightlink_self_href)
+    add_cmd = %W(--rl10 cm15 multi_add /api/tags/multi_add
+                 resource_hrefs[]=#{rightlink_self_href})
+    tag = PuppetX::RightScale::Utils.generate_tag(resource[:name], resource[:value])
+    Puppet.debug("Create tag: #{tag}")
+    rsc(add_cmd << "tags[]=#{tag}")
+  end
+
+  
+  def destroy
+    rightlink_self_href = Facter.value(:rightlink_self_href)
+    delete_cmd = %W(--rl10 cm15 multi_delete /api/tags/multi_delete
+                    resource_hrefs[]=#{rightlink_self_href})
+
+    # rsc is a little weird in that it needs both the name and value of a tag
+    # to pass to the RS API. To delete a tag we need to compose a tag from
+    # resource[:name] and @property_hash[:value]
+    tag = PuppetX::RightScale::Utils.generate_tag(resource[:name], @property_hash[:value])
+    Puppet.debug("Destroy tag: #{tag}")
+    rsc(delete_cmd << "tags[]=#{tag}")
+  end
+
+  
+  # Updating the 'value' of a tag is no different than creating a new tag,
+  # so we just call the create() method.
+  def value=(value)
+    create()
+  end
+end

--- a/lib/puppet/provider/rs_tag/rsc.rb
+++ b/lib/puppet/provider/rs_tag/rsc.rb
@@ -22,7 +22,7 @@
 require 'rubygems'
 require 'json'
 
-require_relative '../../../puppet_x/rightscale/utils.rb'
+require "#{File.join(File.dirname(__FILE__), '..', '..', '..', 'puppet_x', 'rightscale', 'utils')}"
 
 Puppet::Type.type(:rs_tag).provide(:rsc) do
   desc "Manage RightScale tags for a server"

--- a/lib/puppet/type/rs_tag.rb
+++ b/lib/puppet/type/rs_tag.rb
@@ -14,44 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require_relative '../../puppet_x/rightscale/tag.rb'
+
 Puppet::Type.newtype(:rs_tag) do
-  desc "Tags a host in RightScale with the supplied values"
-
-  # Pre-built Regex Patterns for RightScale tag naming.
-  #
-  # Initial tag 'name' (no predicate)
-  rs_tag_name = /^([a-z])([a-z0-9_]+)?/
-  # Optional tag 'predicate'
-  rs_tag_predicate = /:([a-z])([a-z0-9_]+)?/
-
-  ensurable do
-    defaultvalues
-    defaultto :present
-  end
-
-  newparam(:name, :namevar => true) do
-    desc "Tag name - must conform to RightScale standards"
-    validate do |value|
-      unless value =~ /#{rs_tag_name}(#{rs_tag_predicate})?$/
-        raise ArgumentError, "%s is not a valid tag name" % value
-      end
-    end
-  end
-
-  newproperty(:value) do
-    desc "Value of the tag (optional)"
-  end
-
-  validate do
-    # If the supplied name has a name/predicate, then a value MUST be supplied.
-    if self[:name] =~ /#{rs_tag_name}#{rs_tag_predicate}$/ and not self[:value]
-      self.fail "You must supply a `value` if your tag `name` includes a predicate."
-    end
-
-    # If the value is supplied, then the name MUST have a predicate.
-    if not self[:name] =~ /#{rs_tag_name}#{rs_tag_predicate}$/ and self[:value]
-      self.fail "You must name your tag with a predicate if you have supplied a `value`."
-    end
-
-  end
+  extend PuppetX::RightScale::Tag
+  @doc = 'Type representing a RightScale Machine Tag or Raw Tag.'
+  create_properties_and_params
 end

--- a/lib/puppet/type/rs_tag.rb
+++ b/lib/puppet/type/rs_tag.rb
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require_relative '../../puppet_x/rightscale/tag.rb'
+require "#{File.join(File.dirname(__FILE__), '..', '..', 'puppet_x', 'rightscale', 'tag')}"
 
 Puppet::Type.newtype(:rs_tag) do
   extend PuppetX::RightScale::Tag

--- a/lib/puppet_x/rightscale/tag.rb
+++ b/lib/puppet_x/rightscale/tag.rb
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require_relative './utils.rb'
+require "#{File.join(File.dirname(__FILE__), 'utils')}"
 
 module PuppetX
   module RightScale
@@ -45,12 +45,19 @@ module PuppetX
         validate do
           Puppet.debug("Validating the entire Rs_tag Type....")
 
+          if nil == self.provider
+            Puppet.debug("Rs_type#validate:: self.provider does not exist...we are almost " +
+                         "certainly running in rspec-puppet unit test mode and no Mock exist for " +
+                         "Provider...")
+            Puppet.debug("Rs_type#validate:: skipping validate() since we are in unit test mode.")
+            return true
+          end
+
           # It's quite tricky to check that 'value =>' exists for Machine Tags
           # in the various scenarios involving both resource queries and enforcements
           # but I believe this covers *most* of the bases.
 
           Puppet.debug("self:: #{self.to_hash}")
-#          Puppet.debug("self.provider.value:: #{self.provider.value}")
           
           tag_type = PuppetX::RightScale::Utils.validate_tag({:name => self[:name]})
 

--- a/lib/puppet_x/rightscale/tag.rb
+++ b/lib/puppet_x/rightscale/tag.rb
@@ -1,0 +1,98 @@
+# License
+#
+# Copyright 2014 Nextdoor.com, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require_relative './utils.rb'
+
+module PuppetX
+  module RightScale
+    module Tag
+
+      def create_properties_and_params
+        
+        ensurable do
+          defaultvalues
+          defaultto :present
+        end
+
+        
+        newparam(:name, :namevar => true) do
+          validate do |name|
+            PuppetX::RightScale::Utils.validate_tag({:name => name})
+          end
+        end
+
+        
+        newproperty(:value) do
+          validate do |value|
+            PuppetX::RightScale::Utils.validate_tag({:value => value})
+          end
+        end
+
+        
+        validate do
+          Puppet.debug("Validating the entire Rs_tag Type....")
+
+          # It's quite tricky to check that 'value =>' exists for Machine Tags
+          # in the various scenarios involving both resource queries and enforcements
+          # but I believe this covers *most* of the bases.
+
+          Puppet.debug("self:: #{self.to_hash}")
+#          Puppet.debug("self.provider.value:: #{self.provider.value}")
+          
+          tag_type = PuppetX::RightScale::Utils.validate_tag({:name => self[:name]})
+
+          case tag_type
+          when 'Machine'
+            # Name check validated. What about the required 'value =>' in the current mode?
+            fail("self.provider does not exist?!? Should never get here!") unless self.provider
+
+            # query operation request
+            if nil == self[:ensure]
+              Puppet.debug("Detected Rs_tag resource query...")
+              fail("Queried Rs_tag Machine Tag does not have both name and value!") unless
+                self.provider.name and self.provider.value # not that valid .value is :absent
+
+            # delete operation request or absent result
+            elsif :absent == self[:ensure]
+              Puppet.debug("Detected Rs_tag delete operation of absent tag...")
+     
+            # create operation request or successful query operation
+            # Note: Machine Tags require specified property 'value'. Raw tags do not.
+            elsif :present == self[:ensure]
+              
+              # I think this is a create operation because the provider has nothing for a
+              # queried value and yet we are :ensure => present.
+              if :absent == self.provider.value
+                fail("Machine Tag \'#{self[:name]}\' must specify a \'value\'.") unless
+                  nil != self[:value]
+                return true
+              end
+            end
+
+          when 'Raw'
+            fail("Raw Tags cannot have a specified \'value\'!") unless nil == self[:value]
+            
+          when 'Unvalidated'
+            fail("Unvalidated Rs_tag name/type! Should never get here!")
+          end
+            
+        end
+      end
+    end
+  end
+end
+
+          

--- a/lib/puppet_x/rightscale/utils.rb
+++ b/lib/puppet_x/rightscale/utils.rb
@@ -1,0 +1,84 @@
+# License
+#
+# Copyright 2014 Nextdoor.com, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module PuppetX
+  module RightScale
+    module Utils
+
+
+      def self.validate_tag(options = {})
+
+        n_p_sep = '\:'
+        k_v_sep = '='
+
+        namespace_re = '([a-z]{1}[a-z0-9_]+)'
+        predicate_re = '([a-zA-Z]{1}[a-zA-Z0-9_]+)'
+        value_re = '([a-zA-Z\S\t ]+)' # any non-whitespace + tab or space but no newline
+
+        raw_tag_re = '^([a-z0-9_]+)$'
+        machine_tag_key_re = "(#{namespace_re}#{n_p_sep}#{predicate_re})"
+        machine_tag_re = "^(#{machine_tag_key_re}#{k_v_sep}#{value_re})$"
+
+        
+        # If caller requested validation of name...
+        tag_type = 'Unvalidated'
+        if nil != options[:name]
+          if options[:name] =~ Regexp.new(machine_tag_key_re)
+            tag_type = 'Machine'
+          elsif options[:name] =~ Regexp.new(raw_tag_re)
+            tag_type = 'Raw'
+          else
+            fail("Tag \'#{options[:name]}\' validates as neither Machine Tag nor Raw Tag.")
+          end
+        
+          Puppet.debug("Tag \'#{options[:name]}\' validates as #{tag_type} Tag.")
+        end
+
+
+        # If caller requested validation of value...
+        if nil != options[:value]
+          if 'Unvalidated' == tag_type
+            Puppet.debug("Tag name \'#{options[:name]}\' unvalidated per user request.")
+            
+          elsif 'Raw' == tag_type
+            fail("Raw Tags cannot have a specified value per the RightScale Tag spec.")
+
+          elsif options[:value] !~ Regexp.new(value_re)
+            fail(
+              "Tag \'#{options[:name]}\' => \'#{options[:value]}\' " \
+              "value does not pass \'#{value_re}\' validation.")
+            Pupppet.debug("Tag value \'#{options[:value]}\' validates.")
+          end
+        end
+        
+        tag_type
+      end
+
+      
+      def self.generate_tag(name, value)
+        case validate_tag({:name => name, :value => value})
+        when 'Machine'
+          return "#{name}=#{value}"
+        when 'Raw'
+          return name
+        else
+          fail("Tag type is neither Machine nor Raw. Should never get here!")
+        end
+      end
+      
+    end
+  end
+end

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -126,7 +126,7 @@ class rightscale::repos (
     if $mirror {
       apt::source { 'rightscale_security_mirror':
         location => "http://${mirror}/ubuntu_daily/${enable_security}",
-        include  => { 'src' => false },
+        include  => { '::src'        => false },
         release  => "${::lsbdistcodename}-security",
         repos    => 'main restricted universe multiverse';
       }
@@ -134,7 +134,7 @@ class rightscale::repos (
     $loc = "http://${fallback_mirror}/ubuntu_daily/${enable_security}"
     apt::source { 'rightscale_security_fallback':
       location => $loc,
-      include  => { 'src' => false },
+      include  => { '::src'      => false },
       release  => "${::lsbdistcodename}-security",
       repos    => 'main restricted universe multiverse';
     }

--- a/spec/unit/etc/autosigner_spec.rb
+++ b/spec/unit/etc/autosigner_spec.rb
@@ -36,7 +36,7 @@ describe AutoSigner do
 
   it "#new" do
     # Lastly create our AutoSigner object
-    @auto.should be_an_instance_of AutoSigner
+    expect(@auto).to be_an_instance_of AutoSigner
   end
 
   it "#new with debug enabled" do

--- a/spec/unit/facter/rightlink_maj_version_spec.rb
+++ b/spec/unit/facter/rightlink_maj_version_spec.rb
@@ -18,7 +18,7 @@ describe Facter::Util::Fact do
       Facter.clear
       Facter.clear_messages
     end
-    
+
     context "Fact 'rightlink_version' does not exist" do
       it "should return value nil" do
         allow(Facter.fact(:rightlink_version)).to receive(:value).and_return(nil)

--- a/spec/unit/facter/rightlink_self_href_spec.rb
+++ b/spec/unit/facter/rightlink_self_href_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+require 'facter/is_rightscale'
+require 'facter/rightlink_version'
+require 'facter/rightlink_maj_version'
+
+describe Facter::Util::Fact do
+  
+  describe "rightlink_self_href" do
+
+    before do
+      Facter.clear
+      Facter.clear_messages
+      allow(Facter.fact(:kernel)).to receive(:value).and_return('Linux')
+      allow(Facter.fact(:is_rightscale)).to receive(:value).and_return(true)
+    end
+
+    after do
+      Facter.clear
+      Facter.clear_messages
+    end
+
+    context "RightLink 6 is installed" do
+      it "it should return nil" do
+        allow(Facter.fact(:rightlink_version)).to receive(:value).and_return('6.0.0')
+        allow(Facter.fact(:rightlink_maj_version)).to receive(:value).and_return(6)
+        expect(Facter.fact(:rightlink_self_href).value).to eq nil
+      end
+    end
+
+    context "RightLink 10 is installed" do
+      it "should return a valid self href" do
+        allow(Facter.fact(:rightlink_version)).to receive(:value).and_return('10.0.0')
+        allow(Facter.fact(:rightlink_maj_version)).to receive(:value).and_return(10)
+        allow(Facter::Util::Resolution).to receive(:exec).with(
+                                             "rsc --rl10 cm15 --x1 ':has(.rel:val(\"self\")).href'"\
+                                             " index_instance_session /api/sessions/instance"
+                                           ).and_return('api/clouds/6/instances/DEADBEEF')
+        expect(Facter.fact(:rightlink_self_href).value).to eq 'api/clouds/6/instances/DEADBEEF'
+      end
+    end
+    
+  end
+  
+end

--- a/spec/unit/provider/rs_tag/rs_tag_spec.rb
+++ b/spec/unit/provider/rs_tag/rs_tag_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
-require_relative '../../../../lib/puppet/type/rs_tag.rb'
-require_relative '../../../../lib/puppet/provider/rs_tag/rs_tag.rb'
+
+require "#{File.join(File.dirname(__FILE__), '..', '..', '..', '..', 'lib', 'puppet', 'type', 'rs_tag')}"
+require "#{File.join(File.dirname(__FILE__), '..', '..', '..', '..', 'lib', 'puppet', 'provider', 'rs_tag', 'rsc')}"
 
 provider_class = Puppet::Type.type(:rs_tag).provider(:rs_tag)
 

--- a/spec/unit/provider/rs_tag/rs_tag_spec.rb
+++ b/spec/unit/provider/rs_tag/rs_tag_spec.rb
@@ -1,14 +1,12 @@
 require 'spec_helper'
-require "#{File.join(File.dirname(__FILE__),'..','..','..','..','lib','puppet','type','rs_tag')}"
-require "#{File.join(File.dirname(__FILE__),'..','..','..','..','lib','puppet','provider','rs_tag','ruby')}"
+require_relative '../../../../lib/puppet/type/rs_tag.rb'
+require_relative '../../../../lib/puppet/provider/rs_tag/rs_tag.rb'
 
-provider_class = Puppet::Type.type(:rs_tag).provider(:ruby)
+provider_class = Puppet::Type.type(:rs_tag).provider(:rs_tag)
 
 describe provider_class do
-  let(:resource) { Puppet::Type.type(:rs_tag).new(
-    { :name     => 'test',
-      :provider => described_class.name }
-  )}
+  let(:resource) {
+    Puppet::Type.type(:rs_tag).new( { :name => 'test', :provider => described_class.name } )}
   let(:provider) { resource.provider }
   let(:facts) { { :is_rightscale => true, :rightlink_version => '6.0.0', :rightlink_maj_version => 6 } }
 

--- a/spec/unit/provider/rs_tag/rsc_spec.rb
+++ b/spec/unit/provider/rs_tag/rsc_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
-require_relative '../../../../lib/puppet/type/rs_tag.rb'
-require_relative '../../../../lib/puppet/provider/rs_tag/rsc.rb'
+require "#{File.join(File.dirname(__FILE__), '..', '..', '..', '..', 'lib', 'puppet', 'type', 'rs_tag')}"
+require "#{File.join(File.dirname(__FILE__), '..', '..', '..', '..', 'lib', 'puppet', 'provider', 'rs_tag', 'rsc')}"
 
 provider_class = Puppet::Type.type(:rs_tag).provider(:rsc)
 

--- a/spec/unit/provider/rs_tag/rsc_spec.rb
+++ b/spec/unit/provider/rs_tag/rsc_spec.rb
@@ -1,0 +1,118 @@
+require 'spec_helper'
+
+require_relative '../../../../lib/puppet/type/rs_tag.rb'
+require_relative '../../../../lib/puppet/provider/rs_tag/rsc.rb'
+
+provider_class = Puppet::Type.type(:rs_tag).provider(:rsc)
+
+describe provider_class do
+
+  ##
+  ## Start of tests
+  ##
+  context "on RightLink 10" do
+
+    let(:resource) { Puppet::Type.type(:rs_tag).new(
+      { :name     => 'test', :provider => described_class.name } )}
+    let(:provider) { resource.provider }
+
+    before :each do
+      ##
+      ## Set up lots of convenience vars, mocks, etc
+      ##
+      Facter.stubs(:value).with(:is_rightscale).returns(true)
+      Facter.stubs(:value).with(:rightlink_version).returns('10.0.0')
+      Facter.stubs(:value).with(:rightlink_maj_version).returns(10)
+
+      @rightlink_self_href = '/api/clouds/6/instances/DEADBEEF'
+      Facter.stubs(:value).with(:rightlink_self_href).returns(@rightlink_self_href)
+
+      # convenient mocks for the commands executed by Provider
+      @mock_tag_query_cmd = :rsc
+      @mock_tag_query_params = %W(--rl10 cm15 by_resource /api/tags/by_resource
+                             resource_hrefs[]=#{@rightlink_self_href})
+      @mock_tag_add_params = %W(--rl10 cm15 multi_add /api/tags/multi_add
+                           resource_hrefs[]=#{@rightlink_self_href} tags[]=test)
+      @mock_tag_remove_params = %W(--rl10 cm15 multi_delete /api/tags/multi_delete
+                              resource_hrefs[]=#{@rightlink_self_href} tags[]=test)
+
+      Puppet::Util.stubs(:which).with(@mock_tag_query_cmd).returns('/usr/local/bin/rsc')
+
+      # Mocked list of existing tags to run our tests against
+      existing_tags =
+        '[{"actions":[], "links":[], ' + \
+        '"tags":[{"name":"test_tag_1"}, {"name":"test_tag:with_predicate=1"}]}]'
+      provider.class.stubs(@mock_tag_query_cmd).with(@mock_tag_query_params).returns(existing_tags)
+    end
+
+    let(:instance) { provider.class.instances.first }
+
+    describe 'self.prefetch' do
+      it 'exists' do
+        provider.class.instances
+        provider.class.prefetch({})
+      end
+
+      it 'should work with rs_tag failure' do
+        provider.class.stubs(@mock_tag_query_cmd).with(
+          @mock_tag_query_params).raises(Puppet::ExecutionFailure, "Error")
+        expect(provider.class.instances).to eq nil
+        expect(provider.class.prefetch({})).to eq nil
+      end
+    end
+
+    describe 'exists?' do
+      it 'checks if `test` tag exists (should not)' do
+        expect(provider.exists?).to be_falsey
+      end
+    end
+
+    describe 'self.instances' do
+      it 'returns an array of tags' do
+        instances = provider.class.instances.collect {|x| x.name }
+        expect(['test_tag_1', 'test_tag:with_predicate']).to match_array(instances)
+      end
+    end
+    
+    describe 'self.get_tags' do
+      it 'should return a list of providers' do
+        providers = provider.class.get_tags()
+        expect(providers.length).to eq 2
+      end
+    end
+
+    describe 'self.get_tags() with no tags set' do
+      it 'should return an empty array' do
+        existing_tags =
+          '[{"actions":[], "links":[], "tags":[]}]'
+        provider.class.stubs(@mock_tag_query_cmd).with(@mock_tag_query_params).returns(existing_tags)
+        providers = provider.class.get_tags()
+        expect(providers.length).to eq 0
+      end
+    end
+
+    describe 'self.get_tags() with failed rsc output' do
+      it 'should return nil' do
+        existing_tags = 'bogus output'
+        provider.class.stubs(@mock_tag_query_cmd).with(@mock_tag_query_params).returns(existing_tags)
+        providers = provider.class.get_tags()
+        expect(providers).to eq nil
+      end
+    end
+
+    describe 'create' do
+      it 'should allow creation of the tag `test`' do
+        provider.class.expects(@mock_tag_query_cmd).with(@mock_tag_add_params)
+        provider.create
+      end
+    end
+
+    describe 'destroy' do
+      it 'should allow removal of the tag `test`' do
+        provider.class.expects(@mock_tag_query_cmd).with(@mock_tag_remove_params)
+        
+        provider.destroy
+      end
+    end
+  end
+end

--- a/spec/unit/type/rs_tag_spec.rb
+++ b/spec/unit/type/rs_tag_spec.rb
@@ -1,53 +1,85 @@
 require 'spec_helper'
 require "#{File.join(File.dirname(__FILE__),'..','..','..','lib','puppet','type','rs_tag')}"
 
+#supported_rightlink_versions = %w(6 10)
+supported_rightlink_versions = %w(10)
 
 describe Puppet::Type.type(:rs_tag) do
-  let :tag do
-    Puppet::Type.type(:rs_tag).new(
-      :name  => 'test')
-  end
+  supported_rightlink_versions.each do |rightlink_maj_version|
+    rightlink_maj_version = rightlink_maj_version.to_i
+    describe "on RightLink version #{rightlink_maj_version}" do
 
-  it 'name => test' do
-    tag[:name] = 'test'
-    tag[:name].should == 'test'
-  end
+      # mock up an underlying provider to be used by a few of the tests
+      before :each do
+        @provider_class = described_class.provide(:test_provider) do
+          mk_resource_methods
+          def self.instances; []; end
+        end
+        described_class.stubs(:defaultprovider).returns @provider_class
+      end
 
-  it 'name => $!@ should fail' do
-    lambda { tag[:name] = '$!@' }.should raise_error(Puppet::Error)
-  end
+      case rightlink_maj_version
+      when 6
+        let!(:facts) {{
+                        :is_rightscale => true,
+                        :rightlink_version => '6.0.0',
+                        :rightlink_maj_version => 6 }}
+      when 10
+        let!(:facts) {{
+                       :is_rightscale => true,
+                       :rightlink_version => '10.0.0',
+                       :rightlink_maj_version => 10 }}
+      else
+        raise Exception, "Unsupported RightLink version: #{rightlink_maj_version}"
+      end
+      
+      let :tag do
+        Puppet::Type.type(:rs_tag).new(
+          :name  => 'test')
+      end
 
-  it 'name => BadTagName should fail' do
-    lambda { tag[:name] = 'BadTagName' }.should raise_error(Puppet::Error)
-  end
+      it 'name => test' do
+        tag[:name] = 'test'
+        tag[:name].should == 'test'
+      end
 
-  it 'name => missing_predicate: should fail' do
-    lambda { tag[:name] = 'missing_predicate:' }.should raise_error(Puppet::Error)
-  end
+      it 'name => $!@ should fail' do
+        lambda { tag[:name] = '$!@' }.should raise_error(Puppet::Error)
+      end
 
-  it 'name => name:predicate, value => nil should fail' do
-    lambda {
-      Puppet::Type.type(:rs_tag).new(
-      :name  => 'name:predicate')
-    }.should raise_error(Puppet::Error)
-  end
+      it 'name => BadTagName should fail' do
+        lambda { tag[:name] = 'BadTagName' }.should raise_error(Puppet::Error)
+      end
 
-  it 'name => name_without_predicate, value => foobar should fail' do
-    lambda {
-      Puppet::Type.type(:rs_tag).new(
-      :name  => 'name_without_predicate',
-      :value => 'foobar')
-    }.should raise_error(Puppet::Error)
-  end
+      it 'name => missing_predicate: should fail' do
+        lambda { tag[:name] = 'missing_predicate:' }.should raise_error(Puppet::Error)
+      end
 
-  it 'name => name:predicate, value => something' do
-    Puppet::Type.type(:rs_tag).new(
-      :name  => 'name:predicate',
-      :value => 'something')
-  end
+      it 'name => name:predicate, value => nil should fail' do
+        lambda {
+          Puppet::Type.type(:rs_tag).new(
+            :name  => 'name:predicate')
+        }.should raise_error(Puppet::Error)
+      end
 
-  it 'value => test' do
-    tag[:value] = 'test'
-    tag[:value].should == 'test'
+      it 'name => name_without_predicate, value => foobar should fail' do
+        lambda {
+          Puppet::Type.type(:rs_tag).new(
+            :name  => 'name_without_predicate',
+            :value => 'foobar')
+        }.should raise_error(Puppet::Error)
+      end
+
+      it 'name => name:predicate, value => something' do
+        Puppet::Type.type(:rs_tag).new(
+          :name  => 'name:predicate',
+          :value => 'something')
+      end
+
+      it 'value => test' do
+        tag[:value] = 'test'
+        tag[:value].should == 'test'
+      end
+    end
   end
 end

--- a/spec/unit/type/rs_tag_spec.rb
+++ b/spec/unit/type/rs_tag_spec.rb
@@ -1,5 +1,5 @@
 require 'spec_helper'
-require "#{File.join(File.dirname(__FILE__),'..','..','..','lib','puppet','type','rs_tag')}"
+require "#{File.join(File.dirname(__FILE__), '..', '..', '..', 'lib', 'puppet', 'type', 'rs_tag')}"
 
 #supported_rightlink_versions = %w(6 10)
 supported_rightlink_versions = %w(10)


### PR DESCRIPTION

* Add an rsc Provider for the Rs_tag Type in order to enable RL10 support.
  * in the process, cleanup and bugfix for the Type code
    * adopt structure similar to the Puppet AWS module (lib/puppet_x)
    * fixed some prefetch and tag/value validation bugs

* fixed problems with Travis Test pipeline where failing for Ruby 1.8.7 due to rake gem support.

@mikhail @diranged 