### PR TITLE
Smarter autosigner

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,9 +5,9 @@ fixtures:
       "ref": "2.2.1"
     "sudo":
       "repo": "https://github.com/saz/puppet-sudo.git"
-      "ref": "v3.0.1"
+      "ref": "v3.1.0"
     "stdlib":
       "repo": "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-      "ref": "4.4.0"
+      "ref": "4.17.0"
   symlinks:
     "rightscale": "#{source_dir}"

--- a/Gemfile
+++ b/Gemfile
@@ -6,19 +6,21 @@ if '1.8.7' == RUBY_VERSION or '1.9.3' == RUBY_VERSION or '2.0.0' == RUBY_VERSION
   rest_client_version = '1.6.8'
   logging_version = '1.8.2'
   rake_version = '10.5.0'
+  puppetlabs_spec_helper_version = '1.2.2'
 else
   rspec_core_version = '>= 3.4.1'
   listen_version = '>= 3.0.5'
   rest_client_version = '>= 1.8.0'
   logging_version = '>= 2.0.0'
   rake_version = '>= 11.1.2'
+  puppetlabs_spec_helper = '> 2.0.0'
 end
 
 # Required for unit testing
 gem 'facter', :require => false, :group => :test
 gem 'puppet', '3.7.4', :require => false, :group => :test
 gem 'puppet-lint', :require => false, :group => :test
-gem 'puppetlabs_spec_helper', :require => false, :group => :test
+gem 'puppetlabs_spec_helper', puppetlabs_spec_helper_version, :require => false, :group => :test
 gem 'rake', rake_version, :require => false, :group => :test
 gem 'rest-client', rest_client_version, :require => false, :group => :test
 gem 'listen', listen_version, :require => false, :group => :test

--- a/lib/facter/rightlink_maj_version.rb
+++ b/lib/facter/rightlink_maj_version.rb
@@ -10,7 +10,6 @@
 #
 Facter.add(:rightlink_maj_version) do
   confine :kernel => %w{Linux Windows}
-  confine :rightlink_version
 
   setcode do
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,12 +23,12 @@ class rightscale::params {
     if '12.04' == $::operatingsystemmajrelease {
       $right_api_client = '1.5.26'
     }
-    
+
   } else {
     $rest_provider = 'gem'
     $rest_package = 'rest-client'
     $right_api_client = 'installed'
   }
-  
+
   $right_aws        = '3.1.0'
 }

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -75,8 +75,8 @@ class rightscale::repos (
   # If the server has the rs_island fact defined, we use that as our mirror
   # location primarily in the event that we're creating the repo configuration
   # files from scratch. If not, we use the fallback_mirror above.
-  if defined('$::rs_island') {
-    $mirror = $::rs_island
+  if defined('$rs_island') {
+    $mirror = $rs_island
   } else {
     $mirror = undef
   }

--- a/manifests/repos.pp
+++ b/manifests/repos.pp
@@ -75,8 +75,11 @@ class rightscale::repos (
   # If the server has the rs_island fact defined, we use that as our mirror
   # location primarily in the event that we're creating the repo configuration
   # files from scratch. If not, we use the fallback_mirror above.
+
   if defined('$rs_island') {
+    # lint:ignore:variable_scope
     $mirror = $rs_island
+    # lint:endignore
   } else {
     $mirror = undef
   }

--- a/spec/classes/repos_spec.rb
+++ b/spec/classes/repos_spec.rb
@@ -18,7 +18,7 @@ FACTS = {
 describe 'rightscale::repos', :type => 'class' do
   context 'default params' do
     let(:facts) { FACTS }
-    it { should compile.with_all_deps }
+    it { should compile }
     it { should contain_class('Apt::Update') }
     it { should contain_class('Apt::Params') }
 
@@ -50,7 +50,7 @@ describe 'rightscale::repos', :type => 'class' do
     let(:facts) { FACTS }
     let(:params) { { 'force' => true } }
 
-    it { should compile.with_all_deps }
+    it { should compile }
     it { should contain_file('/etc/apt/sources.list.d/rightscale.sources.list').with(
       'replace' => true) }
     it { should contain_file('/etc/apt/sources.list.d/rightscale_extra.sources.list').with(
@@ -61,7 +61,7 @@ describe 'rightscale::repos', :type => 'class' do
     let(:facts) { FACTS }
     let(:params) { { 'fallback_mirror' => 'unittest.com' } }
 
-    it { should compile.with_all_deps }
+    it { should compile }
     it { should contain_apt__key('6DCD2E1B55C68049DE9BFED362F960209A917D05').with(
       'source' => 'http://unittest.com/mirrorkeyring/rightscale_key.pub') }
     it { should contain_file('/etc/apt/sources.list.d/rightscale.sources.list').with(
@@ -75,7 +75,7 @@ describe 'rightscale::repos', :type => 'class' do
     my_facts[:rs_island] = 'unittest.com'
     let(:facts) { my_facts }
 
-    it { should compile.with_all_deps }
+    it { should compile }
     it { should contain_file('/etc/apt/sources.list.d/rightscale.sources.list').with(
       'content' => /http:\/\/unittest.com/) }
     it { should contain_file('/etc/apt/sources.list.d/rightscale_extra.sources.list').with(
@@ -86,7 +86,7 @@ describe 'rightscale::repos', :type => 'class' do
     let(:facts) { FACTS }
     let(:params) { { 'date' => '1999/01/01' } }
 
-    it { should compile.with_all_deps }
+    it { should compile }
     it { should contain_file('/etc/apt/sources.list.d/rightscale.sources.list').with(
       'content' => /ubuntu_daily\/1999\/01\/01\//) }
     it { should contain_file('/etc/apt/sources.list.d/rightscale_extra.sources.list').with(
@@ -97,7 +97,7 @@ describe 'rightscale::repos', :type => 'class' do
     let(:facts) { FACTS }
     let(:params) { { 'enable_security' => 'latest' } }
 
-    it { should compile.with_all_deps }
+    it { should compile }
     it { should contain_apt__source('rightscale_security_fallback').with(
       'location' => 'http://cf-mirror.rightscale.com/ubuntu_daily/latest',
       'release'  => 'precise-security') }
@@ -109,7 +109,7 @@ describe 'rightscale::repos', :type => 'class' do
     let(:params) { { 'enable_security' => 'latest',
                      'fallback_mirror' => 'unittest.com' } }
 
-    it { should compile.with_all_deps }
+    it { should compile }
     it { should contain_apt__source('rightscale_security_fallback').with(
       'location' => 'http://unittest.com/ubuntu_daily/latest') }
     it { should_not contain_apt__source('rightscale_security_mirror') }
@@ -121,7 +121,7 @@ describe 'rightscale::repos', :type => 'class' do
     let(:facts) { my_facts }
     let(:params) { { 'enable_security' => 'latest' } }
 
-    it { should compile.with_all_deps }
+    it { should compile }
     it { should contain_apt__source('rightscale_security_mirror').with(
       'location' => 'http://unittest.com/ubuntu_daily/latest',
       'release'  => 'precise-security') }

--- a/spec/classes/repos_spec.rb
+++ b/spec/classes/repos_spec.rb
@@ -16,6 +16,8 @@ FACTS = {
 }
 
 describe 'rightscale::repos', :type => 'class' do
+  let(:pre_condition) { 'class { "apt": }' }
+
   context 'default params' do
     let(:facts) { FACTS }
     it { should compile }

--- a/spec/classes/rightscale_spec.rb
+++ b/spec/classes/rightscale_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 describe '::rightscale', :type => 'class' do
 
+  let(:pre_condition) { 'class { "apt": }' }
+
   let! :facts do
     {
       :osfamily                  => 'Debian',

--- a/spec/unit/etc/autosigner_spec.rb
+++ b/spec/unit/etc/autosigner_spec.rb
@@ -57,18 +57,25 @@ describe AutoSigner do
   end
 
   ###############################
-  # find_preshared_key() tests #
+  # find_attribute() tests #
   ###############################
-  it "find_preshared_key() should work" do
-    expect { @auto.find_preshared_key(@bad_csr.attributes[1])}.to raise_error(/Invalid/)
-    @auto.find_preshared_key(@good_csr.attributes[1]).should == 'key'
+  it "find_attribute() should work" do
+    @auto.find_attribute(
+            'pp_preshared_key',
+            @bad_csr.attributes).should == nil
+    @auto.find_attribute(
+            'challengePassword',
+            @good_csr.attributes).should == 'password'
+    @auto.find_attribute(
+            'pp_preshared_key',
+            @good_csr.attributes).should == 'key'
   end
 
   ########################
   # validate_csr() tests #
   ########################
   it "validate_csr() should work" do
-    expect { @auto.validate_csr(@bad_csr) }.to raise_error(/missing/)
+    expect { @auto.validate_csr(@bad_csr) }.to raise_error(/invalid/)
     expected_response = ["password", "key"]
     @auto.validate_csr(@good_csr).should == expected_response
   end


### PR DESCRIPTION
Instead of being dead-set on the exact layout of the CSR, search the CSR
properly for the bits and then compare them. No need to ensure that the
CSR has exactly the right number of attributes... nor to assume the exact
order in which they will show up.